### PR TITLE
fix: merging a field with empty array update doesn't overwrite.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+# 0.10.3
+### Fixes
+
+- Fixes `clone` in the case where an empty array is being merged with a non-empty array. Before the
+  arrays were merged. Now the empty array replacing the existing array.
+
 # 0.10.2
 
 ### Fixes

--- a/packages/model/package.json
+++ b/packages/model/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@snapdm/model",
-  "version": "0.10.2",
+  "version": "0.10.3",
   "description": "An opinionated snapshot oriented modeling system for Cloud Firestore",
   "publishConfig": {
     "access": "public"

--- a/packages/model/src/lib/model.spec.ts
+++ b/packages/model/src/lib/model.spec.ts
@@ -10,7 +10,7 @@ type FooInitializer = Readonly<{
   value: string;
 }>;
 
-interface Foo extends FooData {}
+interface Foo extends FooData { }
 
 class Foo extends Model<FooData, FooInitializer>({
   type: 'Foo',
@@ -67,6 +67,33 @@ class Baz extends Model<BazData, BazInitializer>({
     return this.clone({ name });
   }
 }
+
+type WithArrayData = Readonly<{
+  array: string[];
+}>;
+
+interface WithArray extends WithArrayData { }
+
+class WithArray extends Model<WithArrayData, WithArrayData>({
+  type: 'WithArray',
+  collection: 'withArray',
+}) { }
+
+type File = Readonly<{
+  type: string;
+  name: string;
+}>;
+
+type FolderData = Readonly<{
+  files: File[];
+}>;
+
+interface Folder extends FolderData { }
+
+class Folder extends Model<FolderData, FolderData>({
+  type: 'Folder',
+  collection: 'folders',
+}) { }
 
 describe('Model', () => {
   describe('static methods', () => {
@@ -202,6 +229,30 @@ describe('Model', () => {
         expect(baz.name).toEqual(init.name);
         expect(baz.data).toEqual(init.data);
         expect(baz.foo.id).toEqual(foo.id);
+      });
+    });
+  });
+
+  describe('with arrays', () => {
+    describe('simple array', () => {
+      const withArray = new WithArray({ array: ['foo'] });
+
+      [[], ['bar']].forEach((test) => {
+        it('should replace the array', () => {
+          const result = withArray.clone({ array: test });
+          expect(result.array).toEqual(test);
+        });
+      });
+    });
+
+    describe('complex array', () => {
+      const folder = new Folder({ files: [{ type: 'File', name: 'wowza' }] });
+
+      [[], [{ type: 'File', name: 'blue blue' }]].forEach((test) => {
+        it('should replace the array', () => {
+          const result = folder.clone({ files: test });
+          expect(result.files).toEqual(test);
+        });
       });
     });
   });

--- a/packages/model/src/lib/utils/merge.ts
+++ b/packages/model/src/lib/utils/merge.ts
@@ -1,4 +1,4 @@
-import __merge from 'lodash/merge';
+import __mergeWith from 'lodash/mergeWith';
 
 export function merge<T1, T2>(t1: T1, t2: T2): T1 & T2;
 export function merge<T1, T2, T3>(t1: T1, t2: T2, t3: T3): T1 & T2 & T3;
@@ -9,5 +9,7 @@ export function merge<T1, T2, T3, T4>(
   t4: T4
 ): T1 & T2 & T3 & T4;
 export function merge(...sources: unknown[]): unknown {
-  return __merge({}, ...sources);
+  return __mergeWith({}, ...sources, (obj: unknown, val: unknown) =>
+    Array.isArray(obj) ? val : undefined
+  );
 }

--- a/packages/preconditions/package.json
+++ b/packages/preconditions/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@snapdm/preconditions",
-  "version": "0.10.2",
+  "version": "0.10.3",
   "description": "General purpose preconditions for typesafe Typescript libraries",
   "publishConfig": {
     "access": "public"


### PR DESCRIPTION
Adds a failing test for this case and introduces a fix.